### PR TITLE
Optimize range requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ cmake-build-*/
 *.zsync2
 *testfile*
 *.bak
+zsync2*.txt
+*.AppImage*

--- a/include/zsclient.h
+++ b/include/zsclient.h
@@ -56,5 +56,12 @@ namespace zsync2 {
 
         // set path in which the .zsync file should be stored when downloaded first
         void storeZSyncFileInPath(const std::string& path);
+
+        // when set, reduces amount of range requests needed to make to a server by combining nearby ranges
+        // the value determines the distance between two ranges, defining what nearby means
+        // you should set this to multiples of 4 kiB (4096), which is the block size used internally by zsync2
+        // a good value might be 256 kiB (64 blocks, 4 kiB per block)
+        // set to 0 0 to disable any optimizations
+        void setRangesOptimizationThreshold(unsigned long newRangesOptimizationThreshold);
     };
 }

--- a/include/zsutil.h
+++ b/include/zsutil.h
@@ -125,7 +125,7 @@ namespace zsync2 {
 
     static int32_t getPerms(const std::string& path, mode_t& permissions) {
         // check existing permissions
-        struct stat appImageStat;
+        struct stat appImageStat{};
 
         if (stat(path.c_str(), &appImageStat) != 0) {
             return errno;

--- a/scripts/optimize_ranges.py
+++ b/scripts/optimize_ranges.py
@@ -1,0 +1,81 @@
+#! /usr/bin/env python3
+
+from matplotlib import pyplot as plt
+
+import math
+import os
+import sys
+
+
+def get_downloaded_ranges():
+    with open("zsync2_block_analysis.txt") as f:
+        total_size = int(f.readline().split(":")[1]) // 4096
+
+        data = []
+
+        line = f.readline()
+
+        while line:
+            pair = tuple(map(int, (i / 4096 for i in map(int, line.split()))))
+
+            data.append(pair)
+
+            line = f.readline()
+
+        return total_size, data
+
+
+def plot(ranges, file_blocks, h_fields=128):
+    v_fields = math.ceil(25692 / h_fields) + 1
+
+    blocks = [0 for i in range(h_fields * v_fields)]
+
+    for i in range(file_blocks):
+        blocks[i] = 1
+
+    for i, (start, end) in enumerate(ranges):
+        for i in range(start, end+1):
+            blocks[i] = 2
+
+    rows = []
+    for i in range(v_fields):
+        cols = blocks[i*h_fields:(i+1)*h_fields]
+        rows.append(cols)
+
+    plt.imshow(rows)
+    plt.show()
+
+
+def main():
+    file_blocks, ranges = list(get_downloaded_ranges())
+
+    to_download = 0
+    for r in ranges:
+        to_download += r[1] - r[0] + 1
+
+    optimized_ranges = [list(ranges[0])]
+
+    for i, r in enumerate(ranges[1:]):
+        dist = r[0] - optimized_ranges[-1][1]
+
+        if dist <= 64:
+            # extend previous range
+            optimized_ranges[-1][1] = r[1]
+            continue
+
+        optimized_ranges.append(list(r))
+
+    print(optimized_ranges)
+
+    optimized_to_download = 0
+    for r in optimized_ranges:
+        print( r[1] - r[0] + 1)
+        optimized_to_download += r[1] - r[0] + 1
+
+    print("to_download vs optimized_to_download: {} vs. {}".format(to_download, optimized_to_download))
+
+    plot(optimized_ranges, file_blocks)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/plot.py
+++ b/scripts/plot.py
@@ -1,0 +1,59 @@
+#! /usr/bin/env python3
+
+from matplotlib import pyplot as plt
+
+import math
+import os
+import sys
+
+
+def get_downloaded_ranges():
+    with open("zsync2_block_analysis.txt") as f:
+        total_size = int(f.readline().split(":")[1]) // 4096
+
+        data = []
+
+        line = f.readline()
+
+        while line:
+            pair = tuple(map(int, (i / 4096 for i in map(int, line.split()))))
+
+            data.append(pair)
+
+            line = f.readline()
+
+        return total_size, data
+
+
+def main():
+    file_blocks, ranges = list(get_downloaded_ranges())
+
+    to_download = 0
+    for r in ranges:
+        to_download += r[1] - r[0] + 1
+
+    h_fields = 128
+
+    # add one extra row
+    v_fields = math.ceil(25692 / h_fields) + 1
+
+    blocks = [0 for i in range(h_fields * v_fields)]
+
+    for i in range(file_blocks):
+        blocks[i] = 1
+
+    for i, (start, end) in enumerate(ranges):
+        for i in range(start, end+1):
+            blocks[i] = 2
+
+    rows = []
+    for i in range(v_fields):
+        cols = blocks[i*h_fields:(i+1)*h_fields]
+        rows.append(cols)
+
+    plt.imshow(rows)
+    plt.show()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/simulate_download.py
+++ b/scripts/simulate_download.py
@@ -1,0 +1,45 @@
+#! /usr/bin/env python3
+
+import os
+import requests
+import sys
+
+
+def get_downloaded_ranges():
+    with open("zsync2_block_analysis.txt") as f:
+        total_size = int(f.readline().split(":")[1])
+
+        data = []
+
+        line = f.readline()
+
+        while line:
+            data.append(tuple(map(int, line.split())))
+
+            line = f.readline()
+
+        return total_size, data
+
+
+def main():
+    file_size, ranges = list(get_downloaded_ranges())
+
+    with open(os.devnull, "wb") as f:
+        for i, range in enumerate(ranges):
+            print("Requesting range {}".format(i))
+
+            start, end = range
+
+            headers = {
+                "Range": "bytes={}-{}".format(start, end)
+            }
+
+            with requests.get(sys.argv[1], headers=headers, stream=True) as r:
+                f.write(r.raw.read())
+
+    print("done!")
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/src/zsclient.cpp
+++ b/src/zsclient.cpp
@@ -115,8 +115,8 @@ namespace zsync2 {
         };
 
         bool setMtime(time_t mtime) {
-            struct stat s;
-            struct utimbuf u;
+            struct stat s{};
+            struct utimbuf u{};
 
             // get access time (shouldn't be modified)
             if (stat(pathToLocalFile.c_str(), &s) != 0) {

--- a/src/zsclient.cpp
+++ b/src/zsclient.cpp
@@ -619,6 +619,21 @@ namespace zsync2 {
                 }
             }
 
+            // if env var is set, write out ranges that would be downloaded to a file and exit
+            // this helps in debugging performance issues
+            // also note there's CURLOPT_VERBOSE which can be set to show all request and response headers
+            if (getenv("ZSYNC2_ANALYZE_BLOCKS")) {
+                std::ofstream ofs("zsync2_block_analysis.txt");
+
+                ofs << "new file size: " << zsync_filelen(zsHandle) << std::endl;
+
+                std::for_each(ranges.begin(), ranges.end(), [&ofs](const std::pair<int, int>& pair) {
+                    ofs << pair.first << " " << pair.second << std::endl;
+                });
+
+                exit(0);
+            }
+
             // begin downloading ranges, one by one
             {
                 for (const auto& pair : ranges) {

--- a/src/zsclient.cpp
+++ b/src/zsclient.cpp
@@ -646,6 +646,7 @@ namespace zsync2 {
                         /* If error, we need to flag that to our caller */
                         if (len < 0) {
                             ret = -1;
+                            break;
                         }
                         else{    /* Else, let the zsync receiver know that we're at EOF; there
                          *could be data in its buffer that it can use or needs to process */

--- a/src/zsclient.cpp
+++ b/src/zsclient.cpp
@@ -645,7 +645,6 @@ namespace zsync2 {
 
                         /* If error, we need to flag that to our caller */
                         if (len < 0) {
-                            fprintf(stdout, "%d returned\n", len);
                             ret = -1;
                         }
                         else{    /* Else, let the zsync receiver know that we're at EOF; there


### PR DESCRIPTION
I finally got to looking the performance problems reported e.g., in https://github.com/AppImage/AppImageUpdate/issues/112. As expected, the problem lies in the mass of range requests we have to make to fetch all the changes combined with a relatively high latency "modern cloud software" stuff (Git{Lab,Hub}, most object storages, the more layers the worse) induces to process a request and yield a response. The latency adds up with every request, so the higher this latency is, the higher the resulting runtime is.

Now, with regular HTTP servers which directly serve the files, there's no such issues, since these are optimized on serving big chunks of data from files on a disk. Small-scale web software can make use of this even if files are hidden behind an API by providing the path to the web server and having it serve the data directly that way. But with modern web backend software, due to faster and faster systems, this is either not required any more in most use cases or not even viable since files are distributed on a lot of systems (sometimes even different chunks of files are served from different systems).

So how can we solve this? Well, we can't fix these services, so we cannot decrease the per-request latency. To cut down the runtime, all we can do is make less requests. This PR implements an algorithm that combines ranges with rather small "distances" in between (<= 256 kiB), trading data efficiency for better runtimes. In most cases this is an acceptable trade-off, as networks are getting better and better.

The following two charts showcase how the optimization works in a real-life example (a ~100 MiB AppImage that shall be updated with only a few changes):

Before:

![screenshot_2019-09-14_21-56-02](https://user-images.githubusercontent.com/4503202/64914329-75305200-d74f-11e9-8d95-1df5f97e57fa.png)

After.

![screenshot_2019-09-14_22-50-35](https://user-images.githubusercontent.com/4503202/64914333-7b263300-d74f-11e9-9ba1-d981cbb3efaf.png)

Initially, the difference was only 0.5%, which actually proves us true: AppImages should always be delta-updated. However, these 0.5% were spread over 103(!) different ranges.

With the aforementioned optimizations, we have 6 ranges with a total of ~4% of data to be fetched (around 8x more), but only 1/17th of range requests to be made. The file was served from GitLab, and I ran a live test with zsync2 to get some numbers on the runtime. Before we needed 2:25, after only 0:12, which is 1/12th (of course, we don't get the full 1/17th, since there's all the bootup time where `.zsync` files are downloaded and files are hashed, etc.).

More information can be found in https://github.com/AppImage/zsync2/commit/24174f06556e7725c760696341b4c8dc3d2c3c97. I added the changes to zsync2 to get access to the raw ranges and the scripts to visualize and evaluate these data as well, so anyone can conduct their own measurements.

The feature is opt-in right now (`export ZSYNC1_OPTIMIZE_RANGES=1`), but will be made configurable somehow soon (so e.g., AppImageUpdate can switch it on by default, whereas the default `zsync2` shell doesn't do that to maintain the old contracts we inherited from zsync).