### PR TITLE
Report status message in the case of failed digest verification

### DIFF
--- a/src/zsclient.cpp
+++ b/src/zsclient.cpp
@@ -314,8 +314,10 @@ namespace zsync2 {
                     auto response = session.Get();
 
                     bool digestVerified;
-                    if (!verifyInstanceDigest(verificationResponse, response, digestVerified))
+                    if (!verifyInstanceDigest(verificationResponse, response, digestVerified)) {
+                        issueStatusMessage(verificationResponse.error.message);
                         return nullptr;
+                    }
 
                     // expecting a 200 response
                     if (!checkResponseForError(response, 200))


### PR DESCRIPTION
in the case of a failed digest verification issue a status message with the error message from the verification response, this will get fed back to the requesting client and will give some indication in the event of a certificate error.

please see issue 143 in AppImageUpdate
https://github.com/AppImage/AppImageUpdate/issues/143