### PR TITLE
Make linking to custom zlib private in libzsync

### DIFF
--- a/lib/libzsync/CMakeLists.txt
+++ b/lib/libzsync/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library(libzsync zsync.c zmap.c sha1.c)
 set_target_properties(libzsync PROPERTIES PREFIX "")
 
 # link relevant libraries
-target_link_libraries(libzsync zsync2_libz librcksum)
+target_link_libraries(libzsync PRIVATE zsync2_libz PUBLIC librcksum)
 
 # declare includes
 target_include_directories(libzsync PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")


### PR DESCRIPTION
I encountered compile errors in 
zsync2/src/zsclient.cpp due to lib/zlib/zlib.h being included I'm assuming incorrectly since the building instructions suggest installing zlib1g-dev and zlib/zlib.h is missing the gzwrite function (see zlib/zlib.h:980).





