### PR TITLE
Suppress all g++ warnings from specific files

### DIFF
--- a/lib/libzsync/CMakeLists.txt
+++ b/lib/libzsync/CMakeLists.txt
@@ -10,6 +10,9 @@ enable_testing()
 # add actual library
 add_library(libzsync zsync.c zmap.c sha1.c)
 
+# Suppress all g++ warnings from zsync.c and zmap.c
+set_source_files_properties(zsync.c zmap.c PROPERTIES COMPILE_OPTIONS $<$<CXX_COMPILER_ID:GNU>:-w>)
+
 # since the target is called libsomething, one doesn't need CMake's additional lib prefix
 set_target_properties(libzsync PROPERTIES PREFIX "")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,9 @@ set(ZSYNC2_HDRS
 )
 set(ZSYNC2_SRCS zsclient.cpp legacy_http.c legacy_progress.c zsmake.cpp)
 
+# Suppress all g++ warnings from legacy_http.c
+set_source_files_properties(legacy_http.c PROPERTIES COMPILE_OPTIONS $<$<CXX_COMPILER_ID:GNU>:-w>)
+
 # core library
 add_library(libzsync2 ${ZSYNC2_SRCS})
 # since the target is called libsomething, one doesn't need CMake's additional lib prefix


### PR DESCRIPTION
Suppress g++ warnings in zsync.c, zmap.c, and legacy_http.c

Not sure if this is something you are interested in, feel free to decline / close PR. 
But perhaps you feel like this could add value. 