### PR TITLE
Allow other HTTP protocol versions

### DIFF
--- a/src/legacy_http.c
+++ b/src/legacy_http.c
@@ -521,7 +521,7 @@ int range_fetch_read_http_headers(struct range_fetch *rf) {
         }
         if (buf[0] == 0)
             return 0;           /* EOF, caller decides if that's an error */
-        if (memcmp(buf, "HTTP/1", 6) != 0 || (p = strchr(buf, ' ')) == NULL) {
+        if (memcmp(buf, "HTTP/", 5) != 0 || (p = strchr(buf, ' ')) == NULL) {
             log_message("got non-HTTP response '%s'\n", buf);
             return -1;
         }


### PR DESCRIPTION
This widens the check on specific `HTTP/1*` responses and so allows other HTTP protocol versions too (e.g. `HTTP/2`, `HTTP/3`).

Closes #56