### PR TITLE
Extend supported range requests for large files on 64-bit hosts

### DIFF
--- a/src/legacy_http.c
+++ b/src/legacy_http.c
@@ -340,9 +340,9 @@ static int fill_buffer(HTTP_FILE *file, size_t want, CURLM* multi_handle)
  *
  * Removes `want` bytes from the front of the buffer.
  */
-static int use_buffer(HTTP_FILE *file, int want)
+static int use_buffer(HTTP_FILE *file, size_t want)
 {
-    if((file->buffer_pos - want) <= 0){
+    if(file->buffer_pos <= want){
         /* trash the buffer */
         if(file->buffer){
             free(file->buffer);
@@ -509,7 +509,7 @@ static void buflwr(char *s) {
 int range_fetch_read_http_headers(struct range_fetch *rf) {
     char buf[512];
     int status;
-    int seen_location = 0;
+    size_t seen_location = 0;
 
     {                           /* read status line */
         char *p;
@@ -571,7 +571,7 @@ int range_fetch_read_http_headers(struct range_fetch *rf) {
         p += 2;
         buflwr(buf);
         {   /* Remove the trailing \r\n from the value */
-            int len = strcspn(p, "\r\n");
+            size_t len = strcspn(p, "\r\n");
             p[len] = 0;
         }
         /* buf is the header name (lower-cased), p the value */
@@ -580,7 +580,7 @@ int range_fetch_read_http_headers(struct range_fetch *rf) {
         if (status == 206 && !strcmp(buf, "content-range")) {
             /* Okay, we're getting a non-MIME block from the remote. Get the
              * range and set our state appropriately */
-            int from, to;
+            size_t from, to;
             sscanf(p, "bytes " OFF_T_PF "-" OFF_T_PF "/", &from, &to);
             if (from <= to) {
                 rf->block_left = to + 1 - from;


### PR DESCRIPTION
This extends the supported range request sizes and thereby allows download of larger files on 64-bit hosts. Based on initial work by @ghuls (within #31 comments) and @TotallyNotElite (https://github.com/TotallyNotElite/zsync2/commit/aa5d024b25446d4be10bbe17948c7039a6e74334)