### PR TITLE
Make OFF_T_PF less flaky

### DIFF
--- a/src/format_string.h
+++ b/src/format_string.h
@@ -21,17 +21,8 @@
 # define SIZE_T_PF "%u"
 #endif
 
-#if SIZEOF_OFF_T == 8
-# ifdef PRIu64
-#  define OFF_T_PF "%" PRIu64
-# else
-#  define OFF_T_PF "%llu"
-# endif
+#ifdef PRIu64
+# define OFF_T_PF "%" PRIu64
 #else
-# ifdef PRIu32
-#  define OFF_T_PF "%" PRIu32
-# else
-#  define OFF_T_PF "%lu"
-# endif
+# define OFF_T_PF "%llu"
 #endif
-

--- a/src/legacy_http.c
+++ b/src/legacy_http.c
@@ -571,7 +571,7 @@ int range_fetch_read_http_headers(struct range_fetch *rf) {
         p += 2;
         buflwr(buf);
         {   /* Remove the trailing \r\n from the value */
-            int len = strcspn(p, "\r\n");
+            uint64_t len = strcspn(p, "\r\n");
             p[len] = 0;
         }
         /* buf is the header name (lower-cased), p the value */


### PR DESCRIPTION
`SIZEOF_OFF_T` is a macro that is not defined. This means the use of `OFF_T_PF` can be flaky which can lead to incorrect value parsing. For example:

```
sscanf(p, "bytes " OFF_T_PF "-" OFF_T_PF "/", &from, &to);
```
leads to
```
zsync_legacy: bytes 21975040-22482943/2388979712
zsync_legacy: failed to parse content-range header 1079950701759516672 - 22482943
```

Rather than define this macro, this change forces the use of a 64-bit integer via `PRIu64` or `%llu` to support larger range requests. In my testing this makes request range parsing much more robust.